### PR TITLE
replicate owns blocking, exposes block method

### DIFF
--- a/api.md
+++ b/api.md
@@ -30,3 +30,6 @@ returns {} of feeds to replicate, with sequences
 request a given feed, either as request(id) to replicate that feed,
 or request(id, false) to disable replication.
 
+## block: sync
+
+call when `from` blocks `to`: `block(from, to, isBlocking)`. 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     else
       return {
         request: function () {},
+        block: function (from, to, blocking) {},
         changes: function () { return function (abort, cb) { cb(true) } }
       }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cat-names": "^2.0.0",
     "cont": "^1.0.3",
     "dog-names": "^1.0.2",
-    "ssb-friends": "^3.1.11",
+    "ssb-friends": "github:ssbc/ssb-friends#refactor",
     "ssb-gossip": "^1.0.1",
     "ssb-keys": "^7.1.3",
     "ssb-server": "^13.5.2",


### PR DESCRIPTION
replicate should own blocking (consistent with ssb-ebt). This decomplexifies ssb-friends https://github.com/ssbc/ssb-friends/pull/33

there is an edge case noticed, but it wasn't introduced by this PR, it was previously present, and passes tests (no changes to tests).

If a peer is blocked by a feed they are replicating, replication continues until the block message is found. This is no longer good enough, really, because there are more ways to block someone. But the object of this PR isn't to improve behaviour, just have code that is organized better. We can fix that later.