### PR TITLE
console.error err not err.stack

### DIFF
--- a/legacy.js
+++ b/legacy.js
@@ -285,7 +285,7 @@ module.exports = function (ssbServer, notify, config) {
             } else {
               console.error(
                 'Error replicating with ' + rpc.id + ':\n  ',
-                err.stack
+                err
               )
             }
           }


### PR DESCRIPTION
go-ssb doesn't pass errors with `stack` field, so this console.error would show nothing. It seems anyway better to log `err` because it should include `stack` as well as `message`.